### PR TITLE
[codex] Add run-deep-research skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -28,6 +28,15 @@
       ]
     },
     {
+      "name": "run-deep-research",
+      "description": "Skills for deep research with OpenAI, Perplexity, Edison/Falcon, Cyberian, and OpenScientist",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./run-deep-research"
+      ]
+    },
+    {
       "name": "configure-w3id",
       "description": "Skills for setting up a w3id for a linkml project",
       "source": "./",

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For more information, check out:
 
 # About This Repository
 
-This repository contains skills for a variety of curation and knowledge-based tasks. We currently have 4 skills included, but intend to grow this.
+This repository contains skills for a variety of curation and knowledge-based tasks, and we intend to keep growing this collection.
 
 Each skill is self-contained in its own directory with a `SKILL.md` file containing the instructions and metadata that Claude uses. Browse through these examples to get inspiration for your own skills or to understand different patterns and approaches.
 

--- a/run-deep-research/SKILL.md
+++ b/run-deep-research/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: run-deep-research
+description: Run citation-bearing deep research with deep-research-client across OpenAI, Perplexity, Edison/Falcon, Cyberian, and site-specific providers such as OpenScientist. Use when a user asks for research reports, literature reviews, source-backed synthesis, or provider/model trade-off guidance.
+---
+
+# run-deep-research
+
+Use `deep-research-client` for source-backed research tasks that should produce a report with citations and provider metadata.
+
+Canonical project: https://github.com/monarch-initiative/deep-research-client
+
+Do not add a skill `README.md`. The operative agent instructions belong in this `SKILL.md`; the main repository is the human-facing source of broader project context.
+
+## Command Prefix
+
+Select the command form from the current environment:
+
+- In the `deep-research-client` repository, use `uv run deep-research-client ...`.
+- If the package is already installed, use `deep-research-client ...`.
+- If it is not installed and `uv` is available, use `uvx deep-research-client ...`.
+
+Before hard-coding a provider or model, prefer checking local availability:
+
+```bash
+deep-research-client providers
+deep-research-client models
+```
+
+Provider names and aliases can vary by installed version or local deployment. Trust the CLI output over stale examples.
+
+## Provider Selection
+
+Be explicit about speed, depth, cost, and source type. If the user has not already made that trade-off clear, ask before using expensive or long-running providers.
+
+Use this default selection logic:
+
+| Need | Provider guidance |
+| --- | --- |
+| Fast current/web answer | Perplexity `sonar` or `sonar-pro` |
+| Deeper current/web synthesis | Perplexity `sonar-deep-research` |
+| Comprehensive general report | OpenAI deep research |
+| Scientific literature review | Edison/Falcon |
+| Iterative agent-based deep research | Cyberian |
+| Site-specific scientific agent workflow | OpenScientist, only when `providers` reports it |
+
+### Edison/FutureHouse/Falcon Context
+
+Edison Scientific is the successor/spinoff context for the old FutureHouse Falcon integration. The client and older examples may still use the provider name `falcon` for compatibility, while newer docs may say `edison`.
+
+Use whichever provider name the installed CLI reports. Prefer `EDISON_API_KEY`; treat `FUTUREHOUSE_API_KEY` as a legacy fallback if the client supports it.
+
+### Cyberian Context
+
+Cyberian is not a simple hosted API provider. It runs a local agent workflow through `agentapi` using agents such as Claude, Codex, Aider, Cursor, or Goose. Use it when the user wants an exhaustive, iterative research pass and is comfortable with a slow, visible local-agent workflow.
+
+For testing or cost control, consider limiting iterations if the installed Cyberian version supports it:
+
+```bash
+deep-research-client research "query" --provider cyberian \
+  --param agent_type=codex \
+  --param max_iterations=2
+```
+
+### OpenScientist Context
+
+OpenScientist may be exposed by site-specific or newer `deep-research-client` deployments for scientific research workflows. Do not assume the provider name, model name, or setup from memory; use `providers`, `models`, and local docs to confirm availability before invoking it.
+
+## Research Workflow
+
+1. Clarify speed/depth/cost if ambiguous.
+2. Check available providers and models when provider availability is uncertain.
+3. Choose the provider/model according to the user's goal.
+4. Run the research, saving to an output file when the user asks for an artifact or the result will be reused.
+5. Review the result for citations, cache status, provider metadata, and obvious provider failure modes before presenting it.
+
+Minimal command pattern:
+
+```bash
+deep-research-client research "research question" \
+  --provider perplexity \
+  --model sonar-pro \
+  --output research.md
+```
+
+Use `--input-file` for long prompts. Use `--template` and `--var` only when the user supplies a template or when using a bundled template intentionally, such as `examples/gene_research.md`.
+
+## Cache Safety
+
+Treat `~/.deep_research_cache/` as valuable user data. It can contain expensive prior research results and provenance.
+
+- Use the cache by default.
+- Use `list-cache` or `search-cache` freely for non-destructive inspection.
+- Use `--no-cache` only when the user asks for a fresh result or the task clearly requires bypassing stale results.
+- Never run `clear-cache`, delete cache files, or remove `~/.deep_research_cache/` unless the user explicitly asks for cache deletion and confirms they understand it removes saved research.
+
+## Output Expectations
+
+Prefer reports with:
+
+- a clear research question
+- provider/model metadata
+- citations or source links
+- enough synthesis to be useful without rerunning the query
+
+If the selected provider is unavailable, report the exact missing requirement, such as an API key, `agentapi`, Cyberian installation, or an unavailable local provider such as OpenScientist.

--- a/run-deep-research/examples/gene_research.md
+++ b/run-deep-research/examples/gene_research.md
@@ -1,0 +1,38 @@
+# Gene Research Template
+
+Please research the gene {gene} in {organism}, providing a comprehensive analysis focusing on:
+
+## Requested Analysis
+
+1. **Molecular Function and Mechanisms**
+   - Primary molecular function
+   - Key protein interactions
+   - Cellular localization
+   - Post-translational modifications
+
+2. **Disease Associations**
+   - Known disease associations
+   - Mutation effects and pathogenicity
+   - Clinical significance
+   - Therapeutic implications
+
+3. **Expression Patterns**
+   - Tissue-specific expression
+   - Expression in {tissue}
+   - Developmental regulation
+   - Expression changes in disease states
+
+4. **Recent Discoveries**
+   - Key findings since {year}
+   - Novel therapeutic approaches
+   - Emerging research directions
+   - Clinical trials and applications
+
+## Search Parameters
+
+- Gene: {gene}
+- Organism: {organism}
+- Tissue of Interest: {tissue}
+- Time Frame: Research since {year}
+
+Please provide comprehensive citations from peer-reviewed sources and include links to relevant databases (NCBI Gene, UniProt, ClinVar, etc.) where appropriate.


### PR DESCRIPTION
## Summary

Adds the `run-deep-research` skill to the curation skills marketplace, based on the `deep-research-client` repo but trimmed for agent use per the skill-creator guidance.

## Changes

- Adds `run-deep-research/SKILL.md` with concise provider-selection and workflow guidance.
- Keeps the bundled `examples/gene_research.md` template as a reusable resource.
- Registers the skill in `.claude-plugin/marketplace.json`.
- Updates README wording so it no longer advertises an outdated fixed skill count.

## Follow-up Adjustments

- No per-skill README was added; skill-creator guidance says skills should not include auxiliary README files.
- Mentions OpenScientist and Cyberian as providers.
- Explains the Edison / FutureHouse / Falcon naming transition and legacy API key behavior.
- Adds explicit cache safety guidance: agents may inspect cache, but must not clear or delete it without explicit user confirmation.

## Validation

- `uv run python /Users/cjm/.codex/skills/.system/skill-creator/scripts/quick_validate.py run-deep-research`
- `uv run python -m json.tool .claude-plugin/marketplace.json >/dev/null`
- `git diff --check`
- `just --list` was attempted, but this repo has no default `justfile`; `just -f ai.just --list` succeeds and only lists setup/helper recipes.